### PR TITLE
Add MiddlewareChainType

### DIFF
--- a/Sources/BodyParser.swift
+++ b/Sources/BodyParser.swift
@@ -24,12 +24,12 @@ public struct BodyParser: MiddlewareType {
     public func handleRequest(req: Request, res: Response, next: MiddlewareChain) {
 
         guard let body = req.bodyString else {
-            next(nil)
+            next(.Next)
             return
         }
 
         guard let contentType = req.contentType else {
-            next(nil)
+            next(.Next)
             return
         }
 
@@ -37,8 +37,8 @@ public struct BodyParser: MiddlewareType {
         case "application/json":
             do {
                 req.context["jsonBody"] = try JSONParser.parse(body)
-            } catch let err {
-                return next(err)
+            } catch {
+                return next(.Error(error))
             }
 
         case "application/xml":
@@ -55,7 +55,7 @@ public struct BodyParser: MiddlewareType {
             req.context["formData"] = parseURLEncodedString(body)
         }
 
-        next(nil)
+        next(.Next)
     }
 }
 

--- a/Sources/CookieParser.swift
+++ b/Sources/CookieParser.swift
@@ -23,7 +23,7 @@ public struct CookieParser:  MiddlewareType {
     
     public func handleRequest(req: Request, res: Response, next: MiddlewareChain) {
         guard let cookieStr = req.getHeader("cookie") else {
-            return next(nil)
+            return next(.Next)
         }
         
         Process.qwork(onThread: {
@@ -31,7 +31,7 @@ public struct CookieParser:  MiddlewareType {
             req.context["cookie"] = cookie
             req.context["signedCookie"] = CookieParser.signedCookies(cookie, secret: self.secret)
         }, onFinish: {
-            next(nil)
+            next(.Next)
         })
     }
     

--- a/Sources/MiddlewareType.swift
+++ b/Sources/MiddlewareType.swift
@@ -6,7 +6,13 @@
 //  Copyright © 2016 MikeTOKYO. All rights reserved.
 //
 
-public typealias MiddlewareChain = (ErrorType?) -> Void
+
+public enum MiddlewareChainType {
+    case Next
+    case Error(ErrorType)
+}
+
+public typealias MiddlewareChain = (MiddlewareChainType) -> Void
 
 public protocol MiddlewareType {
     func handleRequest(req: Request, res: Response, next: MiddlewareChain) throws

--- a/Sources/SessionHandler.swift
+++ b/Sources/SessionHandler.swift
@@ -55,17 +55,17 @@ public final class SessionHandler: MiddlewareType {
         // main loop
         let onFinish = { [unowned self] in
             if let e = err {
-                next(e)
+                next(.Error(e))
                 return
             }
             
             if res.getHeader("set-cookie") != nil {
-                next(nil)
+                next(.Next)
                 return
             }
             
             guard let sessionId = (req.context["signedCookie"] as? [String: String])?[self.session.keyName] else {
-                next(nil)
+                next(.Next)
                 return
             }
             
@@ -76,7 +76,7 @@ public final class SessionHandler: MiddlewareType {
             })
             
             self.session.reload(sessionId) {
-                next(nil)
+                next(.Next)
             }
         }
         

--- a/Sources/Slimane+Server.swift
+++ b/Sources/Slimane+Server.swift
@@ -56,7 +56,13 @@ extension Slimane {
         middlewares = self.middlewareStack.map { stack in
             return { next in
                 do {
-                    try stack.handler.handleRequest(req, res: res, next: next)
+                    try stack.handler.handleRequest(req, res: res) { result in
+                        if case .Error(let err) = result {
+                            next(err)
+                        } else {
+                            next(nil)
+                        }
+                    }
                 } catch {
                     next(error)
                 }

--- a/Sources/StaticFileServe.swift
+++ b/Sources/StaticFileServe.swift
@@ -19,13 +19,13 @@ public struct StaticFileServe: MiddlewareType {
     
     public func handleRequest(req: Request, res: Response, next: MiddlewareChain) {
         guard let path = req.uri.path else {
-            return next(nil)
+            return next(.Next)
         }
         
         let ext = path.splitBy(".").last!
         
         if !MimeType.matchWithAnyStaticFileExtension(ext) {
-            return next(nil)
+            return next(.Next)
         }
         
         FS.readFile(root + path) { data in
@@ -35,7 +35,7 @@ public struct StaticFileServe: MiddlewareType {
                 res.write(buffer)
                 
             case .Error(let err):
-                next(err)
+                next(.Error(err))
             }
         }
     }


### PR DESCRIPTION
Added MiddlewareChainType for pattern matching dispatch the middleware

``` swift
public enum MiddlewareChainType {
    case Next
    case Error(ErrorType)
}
```
- Next: Go to the next chain
- Error: Abort and respond error

Usage

``` swift
next(.Next)

next(.Error(fooError))
```

Abort case might be added
