### PR TITLE
Add any route matcher

### DIFF
--- a/Sources/Slimane+Router.swift
+++ b/Sources/Slimane+Router.swift
@@ -21,6 +21,10 @@ extension Slimane {
         let middleware = AsyncMiddlewareFactory(handler: handler)
         middlewares.append(middleware)
     }
+    
+    public func any(handler: (Request, Response, HTTPStream) -> ()){
+        self.delegator = handler
+    }
 }
 
 extension Slimane {

--- a/Sources/Slimane+Server.swift
+++ b/Sources/Slimane+Server.swift
@@ -44,6 +44,10 @@ extension Slimane {
                         request.response.merged(try response())
                     }
                 }
+            } else if self.delegator != nil {
+                result {
+                    request.response
+                }
             } else {
                 result {
                     self.errorHandler(Error.RouteNotFound(path: request.uri.path ?? "/"))
@@ -54,7 +58,7 @@ extension Slimane {
         self.middlewares.chain(to: responder).respond(to: request) { [unowned self] in
             do {
                 let response = try $0()
-                if let responder = response.customeResponder {
+                if let responder = response.customResponder {
                     responder.respond(response) {
                         do {
                             self.processStream(try $0(), request, stream)
@@ -62,6 +66,8 @@ extension Slimane {
                             self.handleError(error, request, stream)
                         }
                     }
+                } else if let delegator = self.delegator {
+                    delegator(request, response, stream)
                 } else {
                     self.processStream(response, request, stream)
                 }

--- a/Sources/Slimane.swift
+++ b/Sources/Slimane.swift
@@ -25,6 +25,10 @@ public class Slimane {
     public var backlog: UInt = 1024
 
     public var errorHandler: ErrorProtocol -> Response = defaultErrorHandler
+    
+    // TODO This is interim measures for handle streaming response
+    // untill https://github.com/open-swift/S4/pull/52 get merged.
+    internal var delegator: ((Request, Response, HTTPStream) -> ())? = nil
 
     public init(){
         self.router = Router { _, result in


### PR DESCRIPTION
This is interim measures for handling streaming response untill https://github.com/open-swift/S4/pull/52 is got merged.
### Present Syntax

``` swift
app.any { req, res, stream in
    stream.send("foo".data)
    try! stream.close()
}
```
### Incoming Syntax when Body async cases are merged.

``` swift
app.get("/foo") { req, completion in
    completion {
        Response { stream
            stream.send("foo".data)
             try! stream.close()
        }
    }
}
```
